### PR TITLE
v2.5.0 Feature Work

### DIFF
--- a/src/settings/tokens/languages/html-jsx-css.ts
+++ b/src/settings/tokens/languages/html-jsx-css.ts
@@ -2,12 +2,27 @@ import { Colors } from '../../Theme';
 import TokenSettings from '../TokenSettings';
 
 export default (colors: Colors): TokenSettings[] => [
+  jsxTagPunctuation(colors),
   htmlTags(colors),
   componentTags(colors),
   ...selectors(colors),
   attributeNames(colors),
-  resets(colors)
+  resets(colors),
+  ...css(colors)
 ];
+
+function jsxTagPunctuation({ base }: Colors): TokenSettings {
+  return {
+    name: 'JSX Tag Punctuation',
+    scope: [
+      'punctuation.definition.tag.begin.js',
+      'punctuation.definition.tag.end.js'
+    ],
+    settings: {
+      foreground: base.pink
+    }
+  };
+}
 
 function htmlTags({ base }: Colors): TokenSettings {
   return {
@@ -19,13 +34,12 @@ function htmlTags({ base }: Colors): TokenSettings {
   };
 }
 
-// TODO: red????
 function componentTags({ base }: Colors): TokenSettings {
   return {
     name: 'Component tags',
     scope: ['entity.name.tag support.class.component.js'],
     settings: {
-      foreground: base.purple
+      foreground: base.white
     }
   };
 }
@@ -90,4 +104,26 @@ function resets({ base }: Colors): TokenSettings {
       foreground: base.fg
     }
   };
+}
+
+function css({ base }: Colors): TokenSettings[] {
+  return [
+    {
+      name: 'CSS Property Keys',
+      scope: ['support.constant.property-value.css'],
+      settings: {
+        foreground: base.cyan
+      }
+    },
+    {
+      name: '@media rules',
+      scope: [
+        'keyword.control.at-rule.media.scss',
+        'keyword.control.at-rule.media.scss punctuation.definition.keyword.scss'
+      ],
+      settings: {
+        foreground: base.green
+      }
+    }
+  ];
 }

--- a/src/settings/tokens/languages/typescript.ts
+++ b/src/settings/tokens/languages/typescript.ts
@@ -78,19 +78,23 @@ function classesInUse({ base }: Colors): TokenSettings {
 function typings({ base }: Colors): TokenSettings[] {
   return [
     {
-      name: 'TS Type Aliases and Interfaces',
+      name: 'TS Typing Definitions',
       scope: [
-        'entity.name.type.ts',
         'entity.name.type.alias.ts',
-        'entity.name.type.interface.ts'
+        'entity.name.type.interface.ts',
+        'entity.name.type.enum.ts'
       ],
       settings: {
         foreground: base.green
       }
     },
     {
-      name: 'TS Primitives and Builtins',
-      scope: ['support.type.primitive.ts', 'support.type.builtin.ts'],
+      name: 'TS Typing Uses',
+      scope: [
+        'support.type.primitive.ts',
+        'support.type.builtin.ts',
+        'entity.name.type.ts'
+      ],
       settings: {
         foreground: base.cyan
       }


### PR DESCRIPTION
### JSX Updates

Rethink the way we colorize JSX tags

- Tag brackes (i.e. `<` and `/>`) are all colored pink, like many other punctuation elements
- Component tags are not colored (i.e. are left white), whereas regular DOM tags are colored pink.

I feel this approach makes JSX easier to read, while also maintaining color differentiation b/t Component JSX and DOM Node JSX.

### TypeScript Updates

Refactor TypeScript typings coloring to be more consistent

Throughout JS/TS, we adhere to a pattern where data structure definitions (i.e. classes, functions) are colored green, whereas uses of those same data structures (i.e. function invocation, class extension) are colored cyan.

We break this convention with TypeScript typings. Definitions are often colored cyan, whereas uses are colored green.

Here, we fix this inconsistency. TypeScript typing definitions (i.e. interfaces, enums, type aliases) are always colored green. Uses are always colored cyan.

### CSS Updates

Update some CSS syntax coloring rules

- Property value constants are colored cyan. Language constants used elsewhere (like in media queries) are still colored purple.
- Media query keywords are now colored green