### PR TITLE
Add color for menu highlighting on hover.

### DIFF
--- a/src/settings/Theme.ts
+++ b/src/settings/Theme.ts
@@ -66,4 +66,5 @@ export interface MiscColors {
   bgDark: string;
   bgDarker: string;
   purpleDarker: string;
+  menuHover: string;
 }

--- a/src/settings/colors/index.ts
+++ b/src/settings/colors/index.ts
@@ -17,6 +17,7 @@ import git from './git';
 import inputs from './inputs';
 import lists from './lists';
 import mergeConflicts from './merge-conflicts';
+import menu from './menu';
 import notification from './notification';
 import panels from './panels';
 import peekView from './peek-view';
@@ -47,6 +48,7 @@ export default (colors: Colors) => ({
   ...inputs(colors),
   ...lists(colors),
   ...mergeConflicts(colors),
+  ...menu(colors),
   ...notification(colors),
   ...panels(colors),
   ...peekView(colors),

--- a/src/settings/colors/menu.ts
+++ b/src/settings/colors/menu.ts
@@ -1,0 +1,14 @@
+import { Colors } from '../Theme';
+
+// See: https://code.visualstudio.com/api/references/theme-color#menu-bar-colors
+export default ({ misc }: Colors) => ({
+  'menubar.selectionForeground': null,
+  'menubar.selectionBackground': null,
+  'menubar.selectionBorder': null,
+  'menu.foreGround': null,
+  'menu.background': null,
+  'menu.selectionForeground': null,
+  'menu.selectionBackground': misc.menuHover,
+  'menu.selectionBorder': null,
+  'menu.separatorBackground': null
+});

--- a/src/themes/DraculaAtNight.ts
+++ b/src/themes/DraculaAtNight.ts
@@ -47,7 +47,8 @@ const misc: MiscColors = {
   bgDark: '#21222C',
   bgDarker: '#191A21',
   purpleDarker: '#574473',
-  selection: '#44475A'
+  selection: '#44475A',
+  menuHover: '#3A434D'
 };
 
 const theme: Theme = {


### PR DESCRIPTION
Hi Billy,

dracula-at-night is my favorite VSCode theme and the one I use everywhere.

However one thing I find difficult with it is that it doesn't have a hover color for menus, so it's difficult to see what the selection will be. I added a hover color for that. This includes the top menu and context menus from right-clicks. The color I used is the same as the hover color on the top bar menu.

Any comments are welcome and if you don't like the change please let me know.

Before the change: Here I am hovering over the "new terminal" option (the mouse isn't visible on screen captures).
![Before](https://user-images.githubusercontent.com/12690840/55657718-15726a00-57f3-11e9-96e8-4b00e0149eb1.png)

After the change:
![After](https://user-images.githubusercontent.com/12690840/55657717-14d9d380-57f3-11e9-8317-3c98753066c7.png)
